### PR TITLE
Fix clusterrole in README - Add apiVersion field

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ available.
 kubectl -n kube-system create serviceaccount preoomkiller-controller
 
 cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: preoomkiller-controller


### PR DESCRIPTION
Added apiVerison field in clusterrole creation. Creating with the current version used to throw: `error validating data: apiVersion not set`

cc: @rtnpro 