### PR TITLE
Prevent panic when program exits after SIGTERM

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,7 +209,6 @@ func main() {
 	// Now let's start the controller
 	stopCh := make(chan struct{})
 	go handleSigterm(stopCh)
-	defer close(stopCh)
 	controller.Run(stopCh)
 }
 


### PR DESCRIPTION
In the case where the `main` func is returning, it is because `controller.Run` returned and so `stopCh` has been closed by `handleSigterm` already and cannot be closed again.  Lest there be any fear that this could somehow leave a condition where the channel remains open, consider also that the entire program exits and releases its resources back to the OS.